### PR TITLE
Disable inferred ci setup for JVM

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,6 @@
+dependencies:
+  override:
+    - 'echo "No dependencies needed"'
 test:
   override:
     - 'cd lang/ruby && ./build.sh test'


### PR DESCRIPTION
### What?
Disable downloading Maven dependencies

### Why?
CircleCI detects that projects uses Maven and tries to use it in order to run tests. This leads to timeout in CI builds https://circleci.com/gh/FundingCircle/avro/119 and it's just unnecessary for our changes.