### PR TITLE
Fix Fixnum/Bignum deprecation warnings

### DIFF
--- a/lang/ruby/lib/avro/schema_validator.rb
+++ b/lang/ruby/lib/avro/schema_validator.rb
@@ -165,7 +165,7 @@ module Avro
       private
 
       def actual_value_message(value)
-        avro_type = if value.class == Integer
+        avro_type = if value.is_a?(Integer)
                       ruby_integer_to_avro_type(value)
                     else
                       ruby_to_avro_type(value.class)
@@ -181,8 +181,6 @@ module Avro
         {
           NilClass => 'null',
           String => 'string',
-          Fixnum => 'int',
-          Bignum => 'long',
           Float => 'float',
           Hash => 'record'
         }.fetch(ruby_class, ruby_class)

--- a/lang/ruby/test/test_schema.rb
+++ b/lang/ruby/test/test_schema.rb
@@ -259,7 +259,7 @@ class TestSchema < Test::Unit::TestCase
     assert_equal enum_schema_hash, enum_schema_json.to_avro
   end
 
-def test_empty_record
+  def test_empty_record
     schema = Avro::Schema.parse('{"type":"record", "name":"Empty"}')
     assert_empty(schema.fields)
   end


### PR DESCRIPTION
There was some work done to remove these, but lines 184 and 185 still output warnings.

In order to fix this, I took the approach suggested by @sldblog in https://github.com/FundingCircle/avro/pull/5#discussion_r116469937

This will rely on range check for type instead of class (if it's in `Fixnum` range will use `int`, if it's in `Bignum` range will use `long`).

This will work in both ruby 2.4 and in previous versions.

@sldblog @MiroslavCsonka @sgerrand